### PR TITLE
only enforce PSR2 standards when no rules file is present in project root

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -18,6 +18,17 @@ text_reset=`tput sgr0`
 numberFilesChanged="${#filenames[@]}"
 errorsFound=0
 
+# known php_codesniffer files where it looks for configuration in project root
+phpcs_file=./phpcs.xml
+phpcs_dist_file=./phpcs.xml.dist
+
+# Use PSR2 standard as default only when no phpcs file is present in project root
+if [[ ! -e "$phpcs_file" && ! -e "$phpcs_dist_file" ]]; then
+    default_standard=--standard=PSR2
+else
+    default_standard=""
+fi
+
 
 if [[ $numberFilesChanged > 0 ]];
 then
@@ -28,9 +39,9 @@ then
         if [[ $i == *.php ]] && [ -f $i ];
         then
             # Run PHP Code Beautifier and Fixer first.
-            ./vendor/squizlabs/php_codesniffer/scripts/phpcbf --standard=PSR2 -p $i --diff
+            ./vendor/squizlabs/php_codesniffer/scripts/phpcbf $default_standard -p $i --diff
             # Run PHP Code Style Check and detect in the fixer was not able to fix code.
-            ./vendor/squizlabs/php_codesniffer/scripts/phpcs --standard=PSR2 -p $i
+            ./vendor/squizlabs/php_codesniffer/scripts/phpcs $default_standard -p $i
 
             checkResult=$?
       	    if [ ${checkResult} -eq 0 ];


### PR DESCRIPTION
This should only enforce `PSR2` standards when `phpcs.xml` or `phpcs.xml.dist` do not exist in project


This way should allow developers set their own rules per project