### PR TITLE
bump dependency on git-hooks-installer-plugin to support PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "source": "https://github.com/BernardoSilva/git-hooks-php"
     },
     "require": {
-        "bernardosilva/git-hooks-installer-plugin": "~1.0",
+        "bernardosilva/git-hooks-installer-plugin": "^1.2",
         "squizlabs/php_codesniffer": "^2.0.0"
     }
 }


### PR DESCRIPTION
- [x] bump min dependency on `git-hooks-installer-plugin` to make it compatible with PHP 5.3