### PR TITLE
Extend pre commit to detect bin scripts in sub directories

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -21,6 +21,8 @@ errorsFound=0
 # known php_codesniffer files where it looks for configuration in project root
 phpcs_file=./phpcs.xml
 phpcs_dist_file=./phpcs.xml.dist
+phpcbf_bin="$(find **/vendor/squizlabs/php_codesniffer/bin/phpcbf)"
+phpcs_bin="$(find **/vendor/squizlabs/php_codesniffer/bin/phpcs)"
 
 # Use PSR2 standard as default only when no phpcs file is present in project root
 if [[ ! -e "$phpcs_file" && ! -e "$phpcs_dist_file" ]]; then
@@ -38,9 +40,10 @@ then
         if [[ $i == *.php ]] && [ -f $i ];
         then
             # Run PHP Code Beautifier and Fixer first.
-            ./vendor/squizlabs/php_codesniffer/bin/phpcbf $default_standard -p $i
+            "$($phpcbf_bin $default_standard -p $i)"
+
             # Run PHP Code Style Check and detect in the fixer was not able to fix code.
-            ./vendor/squizlabs/php_codesniffer/bin/phpcs $default_standard -p $i
+            "$($phpcs_bin $default_standard -p $i)"
 
             checkResult=$?
       	    if [ ${checkResult} -eq 0 ];

--- a/pre-commit
+++ b/pre-commit
@@ -40,10 +40,10 @@ then
         if [[ $i == *.php ]] && [ -f $i ];
         then
             # Run PHP Code Beautifier and Fixer first.
-            "$($phpcbf_bin $default_standard -p $i)"
+            output="$($phpcbf_bin $default_standard $i)"
 
             # Run PHP Code Style Check and detect in the fixer was not able to fix code.
-            "$($phpcs_bin $default_standard -p $i)"
+            codestyle_errors="$($phpcs_bin $default_standard $i)"
 
             checkResult=$?
       	    if [ ${checkResult} -eq 0 ];
@@ -51,6 +51,7 @@ then
                 # File had some issues. Now it is fine. Add this file to git again.
                 git add $i
             else
+                echo "$codestyle_errors"
                 ((errorsFound++))
             fi
         fi

--- a/pre-commit
+++ b/pre-commit
@@ -21,8 +21,8 @@ errorsFound=0
 # known php_codesniffer files where it looks for configuration in project root
 phpcs_file=./phpcs.xml
 phpcs_dist_file=./phpcs.xml.dist
-phpcbf_bin="$(find **/vendor/squizlabs/php_codesniffer/bin/phpcbf)"
-phpcs_bin="$(find **/vendor/squizlabs/php_codesniffer/bin/phpcs)"
+phpcbf_bin=$(find . -path "*/vendor/squizlabs/php_codesniffer/bin/phpcbf")
+phpcs_bin=$(find . -path "*/vendor/squizlabs/php_codesniffer/bin/phpcs")
 
 # Use PSR2 standard as default only when no phpcs file is present in project root
 if [[ ! -e "$phpcs_file" && ! -e "$phpcs_dist_file" ]]; then


### PR DESCRIPTION
For example when you have your main project with this structure I can not assume `vendor` dependencies will be installed in project root.

```
- /README.md
- /src
    - /vendor
    - composer.json
```